### PR TITLE
Add trailing slash to Dockerfile COPY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM rust:1.65
 
 WORKDIR /privadex
-COPY Cargo.lock Cargo.toml rust-toolchain.toml .
+COPY Cargo.lock Cargo.toml rust-toolchain.toml ./
 COPY dex_aggregator dex_aggregator
 
 ENV PATH=/home/user/.cargo/bin:$PATH


### PR DESCRIPTION
I get the following error otherwise:

```sh
❯ docker build -t privadex_chain_metadata .
Sending build context to Docker daemon  26.28MB
Step 1/6 : FROM rust:1.65
1.65: Pulling from library/rust
...
Step 3/6 : COPY Cargo.lock Cargo.toml rust-toolchain.toml .
When using COPY with more than one source file, the destination must be a directory and end with a /
```